### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
         "data operations"
     ],
     "description": "Visual diff and merge tool helps compare images in two projects",
-    "docker_image": "supervisely/data-operations:0.0.5",
+    "docker_image": "supervisely/data-operations:6.73.564",
     "instance_version": "6.4.57",
     "main_script": "src/main.py",
     "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -1,29 +1,29 @@
 {
-    "name": "Diff and Merge Images Projects",
-    "type": "app",
-    "categories": [
-        "images",
-        "project management",
-        "data operations"
-    ],
-    "description": "Visual diff and merge tool helps compare images in two projects",
-    "docker_image": "supervisely/data-operations:6.73.564",
-    "instance_version": "6.15.60",
-    "main_script": "src/main.py",
-    "modal_template": "src/modal.html",
-    "modal_width": 585,
-    "modal_template_state": {
-        "teamId1": null,
-        "workspaceId1": null,
-        "projectId1": null,
-        "teamId2": null,
-        "workspaceId2": null,
-        "projectId2": null
-    },
-    "gui_template": "src/gui.html",
-    "task_location": "application_sessions",
-    "isolate": true,
-    "icon": "https://i.imgur.com/DEUcdnP.png",
-    "icon_background": "#FFFFFF",
-    "poster": "https://user-images.githubusercontent.com/106374579/183656137-70a107a9-4497-40be-8e21-1a2c9d8d98f1.png"
+  "name": "Diff and Merge Images Projects",
+  "type": "app",
+  "categories": [
+    "images",
+    "project management",
+    "data operations"
+  ],
+  "description": "Visual diff and merge tool helps compare images in two projects",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "instance_version": "6.15.60",
+  "main_script": "src/main.py",
+  "modal_template": "src/modal.html",
+  "modal_width": 585,
+  "modal_template_state": {
+    "teamId1": null,
+    "workspaceId1": null,
+    "projectId1": null,
+    "teamId2": null,
+    "workspaceId2": null,
+    "projectId2": null
+  },
+  "gui_template": "src/gui.html",
+  "task_location": "application_sessions",
+  "isolate": true,
+  "icon": "https://i.imgur.com/DEUcdnP.png",
+  "icon_background": "#FFFFFF",
+  "poster": "https://user-images.githubusercontent.com/106374579/183656137-70a107a9-4497-40be-8e21-1a2c9d8d98f1.png"
 }

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     ],
     "description": "Visual diff and merge tool helps compare images in two projects",
     "docker_image": "supervisely/data-operations:6.73.564",
-    "instance_version": "6.4.57",
+    "instance_version": "6.15.60",
     "main_script": "src/main.py",
     "modal_template": "src/modal.html",
     "modal_width": 585,

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "data operations"
   ],
   "description": "Visual diff and merge tool helps compare images in two projects",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.70
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
